### PR TITLE
[narwhal] return error when failing to propagate batch to primary or …

### DIFF
--- a/narwhal/worker/src/transactions_server.rs
+++ b/narwhal/worker/src/transactions_server.rs
@@ -156,9 +156,9 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
             .map_err(|_| DagError::ShuttingDown)
             .map_err(|e| Status::not_found(e.to_string()))?;
 
-        // TODO: distingush between a digest being returned vs the channel closing
-        // suggesting an error.
-        let _digest = when_done.await;
+        let _digest = when_done
+            .await
+            .map_err(|_| Status::internal("Failed to propagate transaction for proposal"))?;
 
         Ok(Response::new(Empty {}))
     }


### PR DESCRIPTION
Cherry-pick from upstream: https://github.com/eqlabs/bullshark-bft/commit/3d5f45887bc0807bc0a3a2c9709f66125b7bbe62

> [narwhal] return error when failing to propagate batch to primary or other workers (#8280)
> This commit is now returning an error when failing to propagate batch to workers or (the digest) to primary.