### PR TITLE
Remove unused rocksdb features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,7 +2528,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "zstd-sys",
 ]
 
 [[package]]
@@ -6081,15 +6080,4 @@ dependencies = [
  "quote 1.0.23",
  "syn 1.0.107",
  "synstructure",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]

--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -19,7 +19,7 @@ syn = { version = "1.0.104", features = ["full"] }
 
 [dev-dependencies]
 eyre = "0.6.8"
-rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
+rocksdb = { version = "0.19.0", features = ["lz4", "multi-threaded-cf"], default-features = false }
 tempfile = "3.3.0"
 tokio = { version = "1", features = ["test-util"] }
 typed-store = { path = "../typed-store" }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -19,7 +19,7 @@ num_cpus = "1.14.0"
 prometheus = "0.13.3"
 hdrhistogram = "7.5.1"
 # deactivation of bzip2 due to https://github.com/rust-rocksdb/rust-rocksdb/issues/609
-rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }
+rocksdb = { version = "0.19.0", features = ["lz4", "multi-threaded-cf"], default-features = false }
 serde = { version = "1.0.140", features = ["derive"] }
 thiserror = "1.0.37"
 tokio = { version = "1", features = ["full", "test-util"] }


### PR DESCRIPTION
`zstd` takes quite some time to compile, and since we only need LZ4, it should be safe to remove, along with the other compression algos we're not using.

Let's see what the CI says.