### PR TITLE
Implement metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,7 +4950,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snarkos-node-metrics"
 version = "2.0.2"
-source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#a7148cfbf02696837246d86820f02998cfdc98e5"
+source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#7303985cc01258e14951958ea90502e6c60057be"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4954,7 +4954,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snarkos-node-metrics"
 version = "2.0.2"
-source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#f1871e3195fb49edc84270b69d9c079a90ed1ebe"
+source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3#72fe74f1719a17f2b31fea4f7d7772fb35aeace4"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,7 +2014,7 @@ dependencies = [
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
- "quanta",
+ "quanta 0.9.3",
  "rand",
  "smallvec",
 ]
@@ -2703,6 +2703,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+dependencies = [
+ "ahash 0.7.6",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+dependencies = [
+ "hyper",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "parking_lot",
+ "portable-atomic",
+ "quanta 0.10.1",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown",
+ "metrics",
+ "num_cpus",
+ "parking_lot",
+ "portable-atomic",
+ "quanta 0.10.1",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,6 +2960,7 @@ dependencies = [
  "futures",
  "indexmap",
  "match_opt",
+ "metrics",
  "mysten-util-mem",
  "narwhal-config",
  "narwhal-crypto",
@@ -2913,6 +2972,7 @@ dependencies = [
  "pprof",
  "rand",
  "serde",
+ "snarkos-node-metrics",
  "telemetry-subscribers",
  "thiserror",
  "tokio",
@@ -3020,12 +3080,14 @@ dependencies = [
  "fail",
  "fastcrypto",
  "futures",
+ "metrics",
  "multiaddr",
  "narwhal-crypto",
  "narwhal-test-utils",
  "narwhal-types",
  "rand",
  "serde",
+ "snarkos-node-metrics",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3755,6 +3817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+
+[[package]]
 name = "pprof"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,6 +4063,22 @@ name = "quanta"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -4843,6 +4927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb945e54128e09c43d8e4f1277851bd5044c6fc540bbaa2ad888f60b3da9ae7"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,6 +4946,16 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snarkos-node-metrics"
+version = "2.0.2"
+source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#b5083ebbdb97648fca33b926d60b745fa7e4be8b"
+dependencies = [
+ "metrics",
+ "metrics-exporter-prometheus",
+ "tokio",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,9 +3548,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3580,9 +3580,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,7 +4950,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snarkos-node-metrics"
 version = "2.0.2"
-source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#b5083ebbdb97648fca33b926d60b745fa7e4be8b"
+source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#a7148cfbf02696837246d86820f02998cfdc98e5"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,6 +3039,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "match_opt",
+ "metrics",
  "mockall",
  "multiaddr",
  "narwhal-config",
@@ -3052,6 +3053,7 @@ dependencies = [
  "narwhal-types",
  "rand",
  "serde",
+ "snarkos-node-metrics",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -3171,6 +3173,7 @@ dependencies = [
  "governor",
  "indexmap",
  "itertools",
+ "metrics",
  "mockall",
  "multiaddr",
  "mysten-network",
@@ -3191,6 +3194,7 @@ dependencies = [
  "reqwest",
  "roaring",
  "serde",
+ "snarkos-node-metrics",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -4950,7 +4954,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snarkos-node-metrics"
 version = "2.0.2"
-source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#7303985cc01258e14951958ea90502e6c60057be"
+source = "git+https://github.com/eqlabs/snarkos?branch=bft_testnet3_rebased_metrics#f1871e3195fb49edc84270b69d9c079a90ed1ebe"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235
 
 # metrics
 metrics = "0.20"
-snarkos-metrics = { git = "https://github.com/eqlabs/snarkos", branch = "bft_testnet3_rebased_metrics", package = "snarkos-node-metrics" }
+snarkos-metrics = { git = "https://github.com/eqlabs/snarkos", branch = "bft_testnet3", package = "snarkos-node-metrics" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "0e0ef7054082a6f5a8921688e3d568761bc3be21" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,9 @@ strip = 'none'
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
-
+metrics = "0.20"
 tokio = "1.25.0"
+snarkos-metrics = { git = "https://github.com/eqlabs/snarkos", branch = "bft_testnet3_rebased_metrics", package = "snarkos-node-metrics" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e", package = "fastcrypto-zkp" }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e", package = "fastcrypto-tbls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,14 @@ strip = 'none'
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
-metrics = "0.20"
 tokio = "1.25.0"
-snarkos-metrics = { git = "https://github.com/eqlabs/snarkos", branch = "bft_testnet3_rebased_metrics", package = "snarkos-node-metrics" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e", package = "fastcrypto-zkp" }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e", package = "fastcrypto-tbls" }
+
+# metrics
+metrics = "0.20"
+snarkos-metrics = { git = "https://github.com/eqlabs/snarkos", branch = "bft_testnet3_rebased_metrics", package = "snarkos-node-metrics" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "0e0ef7054082a6f5a8921688e3d568761bc3be21" }

--- a/narwhal/consensus/Cargo.toml
+++ b/narwhal/consensus/Cargo.toml
@@ -7,9 +7,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
+# workspace dependencies
+metrics.workspace = true
+snarkos-metrics.workspace = true
+
+# crates.io dependencies
 arc-swap = { version = "1.5.1", features = ["serde"] }
 bincode = "1.3.3"
 bytes = "1.3.0"
+cfg-if = "1.0.0"
 match_opt = "0.1.2"
 rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0.144", features = ["derive"] }
@@ -17,15 +23,15 @@ thiserror = "1.0.35"
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1.36"
 
+# internal dependencies
 config = { path = "../config", package = "narwhal-config" }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e" }
 crypto = { path = "../crypto", package = "narwhal-crypto" }
-storage = { path = "../storage", package = "narwhal-storage" }
 dag = { path = "../dag", package = "narwhal-dag" }
-types = { path = "../types", package = "narwhal-types" }
-cfg-if = "1.0.0"
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "235211dc8195590f5353d38135f5ee51a267521e" }
 mysten-util-mem = { path = "../../crates/mysten-util-mem" }
+storage = { path = "../storage", package = "narwhal-storage" }
 store = { path = "../../crates/typed-store", package = "typed-store" }
+types = { path = "../types", package = "narwhal-types" }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/narwhal/consensus/Cargo.toml
+++ b/narwhal/consensus/Cargo.toml
@@ -6,10 +6,12 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 publish = false
 
+[features]
+default = ["rand"]
+metrics = ["dep:metrics", "dep:snarkos-metrics"]
+pprof = []
+
 [dependencies]
-# workspace dependencies
-metrics.workspace = true
-snarkos-metrics.workspace = true
 
 # crates.io dependencies
 arc-swap = { version = "1.5.1", features = ["serde"] }
@@ -33,6 +35,14 @@ storage = { path = "../storage", package = "narwhal-storage" }
 store = { path = "../../crates/typed-store", package = "typed-store" }
 types = { path = "../types", package = "narwhal-types" }
 
+[dependencies.metrics]
+workspace = true
+optional = true
+
+[dependencies.snarkos-metrics]
+workspace = true
+optional = true
+
 [dev-dependencies]
 bincode = "1.3.3"
 criterion = "0.4.0"
@@ -44,10 +54,6 @@ node = { path = "../node", package = "narwhal-node" }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.11.0", features = ["criterion", "flamegraph"]}
-
-[features]
-default = ["rand"]
-pprof = []
 
 [lib]
 bench = false

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -8,6 +8,8 @@ use crate::{
 use config::{Committee, Stake};
 use crypto::PublicKey;
 use fastcrypto::traits::EncodeDecodeBase64;
+use metrics::counter;
+use snarkos_metrics::increment_counter;
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::time::Instant;
 use tracing::{debug, trace};
@@ -180,6 +182,7 @@ impl ConsensusProtocol for Bullshark {
         self.last_successful_leader_election_timestamp = Instant::now();
 
         // TODO(metrics): Increment leader_election_elected
+        increment_counter!(snarkos_metrics::consensus::LEADERS_ELECTED);
 
         // The total leader_commits are expected to grow the same amount on validators,
         // but strong vs weak counts are not expected to be the same across validators.
@@ -205,6 +208,10 @@ impl ConsensusProtocol for Bullshark {
         );
 
         // TODO(metrics): Set committed_certificates to `total_committed_certificates as f64`
+        counter!(
+            snarkos_metrics::consensus::COMMITTED_CERTIFICATES,
+            total_committed_certificates as u64
+        );
 
         Ok(committed_sub_dags)
     }

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -8,7 +8,7 @@ use crate::{
 use config::{Committee, Stake};
 use crypto::PublicKey;
 use fastcrypto::traits::EncodeDecodeBase64;
-use snarkos_metrics::{gauge, increment_counter};
+use snarkos_metrics::{gauge, histogram, increment_counter};
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::time::Instant;
 use tracing::{debug, trace};
@@ -174,9 +174,12 @@ impl ConsensusProtocol for Bullshark {
         }
 
         // record the last time we got a successful leader election
-        let _elapsed = self.last_successful_leader_election_timestamp.elapsed();
+        let elapsed = self.last_successful_leader_election_timestamp.elapsed();
 
-        // TODO(metrics): Set commit_rounds_latency to `elapsed.as_secs_f64()`
+        histogram!(
+            snarkos_metrics::consensus::COMMIT_ROUNDS_LATENCY,
+            elapsed.as_secs_f64()
+        );
 
         self.last_successful_leader_election_timestamp = Instant::now();
 
@@ -205,7 +208,6 @@ impl ConsensusProtocol for Bullshark {
             total_committed_certificates
         );
 
-        // TODO(metrics): Set committed_certificates to `total_committed_certificates as f64`
         gauge!(
             snarkos_metrics::consensus::COMMITTED_CERTIFICATES,
             total_committed_certificates as f64

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -8,8 +8,7 @@ use crate::{
 use config::{Committee, Stake};
 use crypto::PublicKey;
 use fastcrypto::traits::EncodeDecodeBase64;
-use metrics::counter;
-use snarkos_metrics::increment_counter;
+use snarkos_metrics::{gauge, increment_counter};
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::time::Instant;
 use tracing::{debug, trace};
@@ -181,7 +180,6 @@ impl ConsensusProtocol for Bullshark {
 
         self.last_successful_leader_election_timestamp = Instant::now();
 
-        // TODO(metrics): Increment leader_election_elected
         increment_counter!(snarkos_metrics::consensus::LEADERS_ELECTED);
 
         // The total leader_commits are expected to grow the same amount on validators,
@@ -208,9 +206,9 @@ impl ConsensusProtocol for Bullshark {
         );
 
         // TODO(metrics): Set committed_certificates to `total_committed_certificates as f64`
-        counter!(
+        gauge!(
             snarkos_metrics::consensus::COMMITTED_CERTIFICATES,
-            total_committed_certificates as u64
+            total_committed_certificates as f64
         );
 
         Ok(committed_sub_dags)

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -9,7 +9,6 @@ use config::Committee;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
 use metrics::gauge;
-use snarkos_metrics::counter;
 use std::{
     cmp::{max, Ordering},
     collections::{BTreeMap, HashMap},
@@ -153,9 +152,9 @@ impl ConsensusState {
         self.last_committed_round = max(self.last_committed_round, certificate.round());
 
         // TODO(metrics): Set last_committed_round to `self.last_committed_round as i64`
-        counter!(
+        gauge!(
             snarkos_metrics::consensus::LAST_COMMITTED_ROUND,
-            self.last_committed_round
+            self.last_committed_round as f64
         );
 
         let elapsed = certificate.metadata.created_at.elapsed().as_secs_f64();

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -8,6 +8,8 @@ use crate::{ConsensusError, SequenceNumber};
 use config::Committee;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
+use metrics::gauge;
+use snarkos_metrics::counter;
 use std::{
     cmp::{max, Ordering},
     collections::{BTreeMap, HashMap},
@@ -151,10 +153,18 @@ impl ConsensusState {
         self.last_committed_round = max(self.last_committed_round, certificate.round());
 
         // TODO(metrics): Set last_committed_round to `self.last_committed_round as i64`
+        counter!(
+            snarkos_metrics::consensus::LAST_COMMITTED_ROUND,
+            self.last_committed_round
+        );
 
         let elapsed = certificate.metadata.created_at.elapsed().as_secs_f64();
 
         // TODO(metrics): Set certificate_commit_latency to `certificate.metadata.created_at.elapsed().as_secs_f64()`
+        gauge!(
+            snarkos_metrics::consensus::CERTIFICATE_COMMIT_LATENCY,
+            certificate.metadata.created_at.elapsed().as_secs_f64()
+        );
 
         // NOTE: This log entry is used to compute performance.
         tracing::debug!(

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -163,7 +163,8 @@ impl ConsensusState {
         // TODO(metrics): Set certificate_commit_latency to `certificate.metadata.created_at.elapsed().as_secs_f64()`
         gauge!(
             snarkos_metrics::consensus::CERTIFICATE_COMMIT_LATENCY,
-            certificate.metadata.created_at.elapsed().as_secs_f64()
+            certificate.metadata.created_at.elapsed().as_secs_f64(),
+            "certificate_round" => certificate.round()
         );
 
         // NOTE: This log entry is used to compute performance.

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -164,7 +164,8 @@ impl ConsensusState {
         gauge!(
             snarkos_metrics::consensus::CERTIFICATE_COMMIT_LATENCY,
             certificate.metadata.created_at.elapsed().as_secs_f64(),
-            "certificate_round" => certificate.round()
+            "certificate_round" => certificate.round().to_string(),
+            "certificate_epoch" => certificate.epoch().to_string(),
         );
 
         // NOTE: This log entry is used to compute performance.

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -8,7 +8,6 @@ use crate::{ConsensusError, SequenceNumber};
 use config::Committee;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
-use snarkos_metrics::{gauge, histogram};
 use std::{
     cmp::{max, Ordering},
     collections::{BTreeMap, HashMap},
@@ -24,6 +23,9 @@ use types::{
     Certificate, CertificateDigest, CommittedSubDag, ConditionalBroadcastReceiver, ConsensusStore,
     Round, StoreResult, Timestamp,
 };
+
+#[cfg(feature = "metrics")]
+use snarkos_metrics::{gauge, histogram};
 
 #[cfg(test)]
 #[path = "tests/consensus_tests.rs"]
@@ -151,6 +153,7 @@ impl ConsensusState {
             .or_insert_with(|| certificate.round());
         self.last_committed_round = max(self.last_committed_round, certificate.round());
 
+        #[cfg(feature = "metrics")]
         gauge!(
             snarkos_metrics::consensus::LAST_COMMITTED_ROUND,
             self.last_committed_round as f64
@@ -158,6 +161,7 @@ impl ConsensusState {
 
         let elapsed = certificate.metadata.created_at.elapsed().as_secs_f64();
 
+        #[cfg(feature = "metrics")]
         histogram!(
             snarkos_metrics::consensus::CERTIFICATE_COMMIT_LATENCY,
             certificate.metadata.created_at.elapsed().as_secs_f64(),

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -8,7 +8,7 @@ use crate::{ConsensusError, SequenceNumber};
 use config::Committee;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
-use metrics::gauge;
+use snarkos_metrics::{gauge, histogram};
 use std::{
     cmp::{max, Ordering},
     collections::{BTreeMap, HashMap},
@@ -151,7 +151,6 @@ impl ConsensusState {
             .or_insert_with(|| certificate.round());
         self.last_committed_round = max(self.last_committed_round, certificate.round());
 
-        // TODO(metrics): Set last_committed_round to `self.last_committed_round as i64`
         gauge!(
             snarkos_metrics::consensus::LAST_COMMITTED_ROUND,
             self.last_committed_round as f64
@@ -159,8 +158,7 @@ impl ConsensusState {
 
         let elapsed = certificate.metadata.created_at.elapsed().as_secs_f64();
 
-        // TODO(metrics): Set certificate_commit_latency to `certificate.metadata.created_at.elapsed().as_secs_f64()`
-        gauge!(
+        histogram!(
             snarkos_metrics::consensus::CERTIFICATE_COMMIT_LATENCY,
             certificate.metadata.created_at.elapsed().as_secs_f64(),
             "certificate_round" => certificate.round().to_string(),

--- a/narwhal/executor/Cargo.toml
+++ b/narwhal/executor/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 publish = false
 
 [dependencies]
+metrics.workspace = true
+snarkos-metrics.workspace = true
+
 async-trait = "0.1.61"
 bincode = "1.3.3"
 bytes = "1.3.0"

--- a/narwhal/executor/Cargo.toml
+++ b/narwhal/executor/Cargo.toml
@@ -6,10 +6,10 @@ license = "Apache-2.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 publish = false
 
-[dependencies]
-metrics.workspace = true
-snarkos-metrics.workspace = true
+[features]
+metrics = ["dep:metrics", "dep:snarkos-metrics"]
 
+[dependencies]
 async-trait = "0.1.61"
 bincode = "1.3.3"
 bytes = "1.3.0"
@@ -42,6 +42,14 @@ store = { path = "../../crates/typed-store", package = "typed-store" }
 
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "0e0ef7054082a6f5a8921688e3d568761bc3be21" }
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "0e0ef7054082a6f5a8921688e3d568761bc3be21" }
+
+[dependencies.metrics]
+workspace = true
+optional = true
+
+[dependencies.snarkos-metrics]
+workspace = true
+optional = true
 
 [dev-dependencies]
 indexmap = { version = "1.9.2", features = ["serde"] }

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use fastcrypto::hash::Hash;
 use rand::prelude::SliceRandom;
 use rand::rngs::ThreadRng;
+use snarkos_metrics::histogram;
 use tokio::time::Instant;
 use tokio::{sync::oneshot, task::JoinHandle};
 use tracing::{debug, error, warn};
@@ -217,7 +218,12 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
             let output_cert = cert.clone();
 
             // TODO(metrics): Set `subscriber_current_round` to `cert.round() as i64`.
-            // TODO(metrics): Set `subscriber_certificate_latency` to `cert.metadata.created_at.elapsed().as_secs_f64()`.
+            histogram!(
+                snarkos_metrics::subscribers::CERTIFICATE_LATENCY,
+                cert.metadata.created_at.elapsed().as_secs_f64(),
+                "certificate_round" => cert.round().to_string(),
+                "certificate_epoch" => cert.epoch().to_string(),
+            );
 
             for (digest, (worker_id, _)) in cert.header.payload.iter() {
                 // TODO(metrics): Increment `subscriber_processed_batches` by 1.

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -19,7 +19,6 @@ use async_trait::async_trait;
 use fastcrypto::hash::Hash;
 use rand::prelude::SliceRandom;
 use rand::rngs::ThreadRng;
-use snarkos_metrics::histogram;
 use tokio::time::Instant;
 use tokio::{sync::oneshot, task::JoinHandle};
 use tracing::{debug, error, warn};
@@ -28,6 +27,9 @@ use types::{
     Batch, BatchDigest, Certificate, CommittedSubDag, ConditionalBroadcastReceiver,
     ConsensusOutput, Timestamp,
 };
+
+#[cfg(feature = "metrics")]
+use snarkos_metrics::histogram;
 
 /// The `Subscriber` receives certificates sequenced by the consensus and waits until the
 /// downloaded all the transactions references by the certificates; it then
@@ -218,6 +220,8 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
             let output_cert = cert.clone();
 
             // TODO(metrics): Set `subscriber_current_round` to `cert.round() as i64`.
+
+            #[cfg(feature = "metrics")]
             histogram!(
                 snarkos_metrics::subscribers::CERTIFICATE_LATENCY,
                 cert.metadata.created_at.elapsed().as_secs_f64(),

--- a/narwhal/network/Cargo.toml
+++ b/narwhal/network/Cargo.toml
@@ -6,9 +6,10 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 publish = false
 
+[features]
+metrics = ["dep:metrics", "dep:snarkos-metrics"]
+
 [dependencies]
-metrics.workspace = true
-snarkos-metrics.workspace = true
 async-trait = "0.1.61"
 backoff = { version = "0.4.0", features = ["tokio"] }
 bytes = "1.3.0"
@@ -34,6 +35,14 @@ axum = "0.6.2"
 axum-server = "0.4.2"
 tower = "0.4.13"
 fail = "0.5.1"
+
+[dependencies.metrics]
+workspace = true
+optional = true
+
+[dependencies.snarkos-metrics]
+workspace = true
+optional = true
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/narwhal/network/Cargo.toml
+++ b/narwhal/network/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
+metrics.workspace = true
+snarkos-metrics.workspace = true
 async-trait = "0.1.61"
 backoff = { version = "0.4.0", features = ["tokio"] }
 bytes = "1.3.0"

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anemo::PeerId;
+use metrics::{histogram, gauge};
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
@@ -49,6 +50,8 @@ impl ConnectionMonitor {
         // TODO(metrics): Set `network_peers` to `connected_peers.len() as i64`
 
         // now report the connected peers
+        let mut peer_count: usize = connected_peers.len();
+        histogram!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
         for peer_id in connected_peers {
             self.handle_peer_connect(peer_id);
         }
@@ -56,9 +59,13 @@ impl ConnectionMonitor {
         while let Ok(event) = subscriber.recv().await {
             match event {
                 anemo::types::PeerEvent::NewPeer(peer_id) => {
+                    peer_count += 1;
+                    histogram!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
                     self.handle_peer_connect(peer_id);
                 }
                 anemo::types::PeerEvent::LostPeer(peer_id, _) => {
+                    peer_count = peer_count.saturating_sub(1);
+                    histogram!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
                     self.handle_peer_disconnect(peer_id);
                 }
             }
@@ -66,18 +73,18 @@ impl ConnectionMonitor {
     }
 
     fn handle_peer_connect(&self, peer_id: PeerId) {
-        // TODO(metrics): Increment `network_peers` by 1
+        use snarkos_metrics::network::labels::PEER_ID;
 
-        if let Some(_ty) = self.peer_id_types.get(&peer_id) {
-            // TODO(metrics): Set `network_peer_connected` to 1
+        if let Some(ty) = self.peer_id_types.get(&peer_id) {
+            gauge!(snarkos_metrics::network::NETWORK_PEER_CONNECTED, 1.0, PEER_ID => ty.to_string());
         }
     }
 
     fn handle_peer_disconnect(&self, peer_id: PeerId) {
-        // TODO(metrics): Decrement `network_peers` by 1
-
-        if let Some(_ty) = self.peer_id_types.get(&peer_id) {
-            // TODO(metrics): Set `network_peer_connected` to 0
+        use snarkos_metrics::network::labels::PEER_ID;
+        
+        if let Some(ty) = self.peer_id_types.get(&peer_id) {
+            gauge!(snarkos_metrics::network::NETWORK_PEER_CONNECTED, 0.0, PEER_ID => ty.to_string());
         }
     }
 }

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anemo::PeerId;
-use metrics::gauge;
+use snarkos_metrics::gauge;
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anemo::PeerId;
-use metrics::{histogram, gauge};
+use metrics::gauge;
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
@@ -51,7 +51,7 @@ impl ConnectionMonitor {
 
         // now report the connected peers
         let mut peer_count: usize = connected_peers.len();
-        histogram!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
+        gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
         for peer_id in connected_peers {
             self.handle_peer_connect(peer_id);
         }
@@ -60,12 +60,12 @@ impl ConnectionMonitor {
             match event {
                 anemo::types::PeerEvent::NewPeer(peer_id) => {
                     peer_count += 1;
-                    histogram!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
+                    gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
                     self.handle_peer_connect(peer_id);
                 }
                 anemo::types::PeerEvent::LostPeer(peer_id, _) => {
                     peer_count = peer_count.saturating_sub(1);
-                    histogram!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
+                    gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
                     self.handle_peer_disconnect(peer_id);
                 }
             }
@@ -82,7 +82,7 @@ impl ConnectionMonitor {
 
     fn handle_peer_disconnect(&self, peer_id: PeerId) {
         use snarkos_metrics::network::labels::PEER_ID;
-        
+
         if let Some(ty) = self.peer_id_types.get(&peer_id) {
             gauge!(snarkos_metrics::network::NETWORK_PEER_CONNECTED, 0.0, PEER_ID => ty.to_string());
         }

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anemo::PeerId;
-use snarkos_metrics::gauge;
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
+#[cfg(feature = "metrics")]
+use snarkos_metrics::gauge;
+
 pub struct ConnectionMonitor {
     network: anemo::NetworkRef,
+
+    // Only used with metrics, but not worth the effort to make it conditional.
+    #[allow(dead_code)]
     peer_id_types: HashMap<PeerId, String>,
 }
 
@@ -51,7 +56,10 @@ impl ConnectionMonitor {
 
         // now report the connected peers
         let mut peer_count: usize = connected_peers.len();
+        #[cfg(feature = "metrics")]
         gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
+
+        #[cfg(feature = "metrics")]
         for peer_id in connected_peers {
             self.handle_peer_connect(peer_id);
         }
@@ -59,19 +67,28 @@ impl ConnectionMonitor {
         while let Ok(event) = subscriber.recv().await {
             match event {
                 anemo::types::PeerEvent::NewPeer(peer_id) => {
+                    _ = peer_id;
                     peer_count += 1;
-                    gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
-                    self.handle_peer_connect(peer_id);
+                    #[cfg(feature = "metrics")]
+                    {
+                        gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
+                        self.handle_peer_connect(peer_id);
+                    }
                 }
                 anemo::types::PeerEvent::LostPeer(peer_id, _) => {
+                    _ = peer_id;
                     peer_count = peer_count.saturating_sub(1);
-                    gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
-                    self.handle_peer_disconnect(peer_id);
+                    #[cfg(feature = "metrics")]
+                    {
+                        gauge!(snarkos_metrics::network::NETWORK_PEERS, peer_count as f64);
+                        self.handle_peer_disconnect(peer_id);
+                    }
                 }
             }
         }
     }
 
+    #[cfg(feature = "metrics")]
     fn handle_peer_connect(&self, peer_id: PeerId) {
         use snarkos_metrics::network::labels::PEER_ID;
 
@@ -80,6 +97,7 @@ impl ConnectionMonitor {
         }
     }
 
+    #[cfg(feature = "metrics")]
     fn handle_peer_disconnect(&self, peer_id: PeerId) {
         use snarkos_metrics::network::labels::PEER_ID;
 

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -12,6 +12,7 @@ pub struct ConnectionMonitor {
     network: anemo::NetworkRef,
 
     // Only used with metrics, but not worth the effort to make it conditional.
+    // TODO(metrics): Make this conditional at some point?
     #[allow(dead_code)]
     peer_id_types: HashMap<PeerId, String>,
 }
@@ -51,8 +52,6 @@ impl ConnectionMonitor {
             // TODO(metrics): Set `network_peer_connected` to 0
         }
         */
-
-        // TODO(metrics): Set `network_peers` to `connected_peers.len() as i64`
 
         // now report the connected peers
         let mut peer_count: usize = connected_peers.len();

--- a/narwhal/node/Cargo.toml
+++ b/narwhal/node/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 publish = false
 
+[features]
+metrics = ["consensus/metrics", "executor/metrics", "network/metrics", "primary/metrics"]
+
 [dependencies]
 arc-swap = { version = "1.5.1", features = ["serde"] }
 async-trait = "0.1.61"
@@ -38,6 +41,7 @@ primary = { path = "../primary", package = "narwhal-primary" }
 storage = { path = "../storage", package = "narwhal-storage" }
 types = { path = "../types", package = "narwhal-types" }
 worker = { path = "../worker", package = "narwhal-worker" }
+
 eyre = "0.6.8"
 serde = {version = "1.0.144", features = ["derive"]}
 roaring = "0.10.1"

--- a/narwhal/primary/Cargo.toml
+++ b/narwhal/primary/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 edition = "2021"
 
 [dependencies]
+metrics.workspace = true
+snarkos-metrics.workspace = true
+
 anyhow = "1.0.65"
 arc-swap = "1.5.1"
 async-trait = "0.1.61"

--- a/narwhal/primary/Cargo.toml
+++ b/narwhal/primary/Cargo.toml
@@ -6,10 +6,10 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 publish = false
 edition = "2021"
 
-[dependencies]
-metrics.workspace = true
-snarkos-metrics.workspace = true
+[features]
+metrics = ["dep:metrics", "dep:snarkos-metrics"]
 
+[dependencies]
 anyhow = "1.0.65"
 arc-swap = "1.5.1"
 async-trait = "0.1.61"
@@ -49,6 +49,14 @@ mysten-network = { path = "../../crates/mysten-network" }
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "0e0ef7054082a6f5a8921688e3d568761bc3be21" }
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "0e0ef7054082a6f5a8921688e3d568761bc3be21" }
 fail = "0.5.1"
+
+[dependencies.metrics]
+workspace = true
+optional = true
+
+[dependencies.snarkos-metrics]
+workspace = true
+optional = true
 
 [dev-dependencies]
 arc-swap = { version = "1.5.1", features = ["serde"] }

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -5,6 +5,7 @@ use crate::NetworkModel;
 use config::{Committee, Epoch, WorkerId};
 use crypto::{PublicKey, Signature};
 use fastcrypto::{hash::Hash as _, signature_service::SignatureService};
+use snarkos_metrics::gauge;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use storage::ProposerStore;
@@ -433,6 +434,7 @@ impl Proposer {
                 self.round += 1;
                 let _ = self.tx_narwhal_round_updates.send(self.round);
                 // TODO(metrics): Set `current_round` to `self.round as i64`
+                gauge!(snarkos_metrics::primary::CURRENT_ROUND, self.round as f64);
                 debug!("Dag moved to round {}", self.round);
 
                 // Make a new header.

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -5,7 +5,6 @@ use crate::NetworkModel;
 use config::{Committee, Epoch, WorkerId};
 use crypto::{PublicKey, Signature};
 use fastcrypto::{hash::Hash as _, signature_service::SignatureService};
-use snarkos_metrics::gauge;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use storage::ProposerStore;
@@ -24,6 +23,9 @@ use types::{
     BatchDigest, Certificate, Header, Round, TimestampMs,
 };
 use types::{now, ConditionalBroadcastReceiver};
+
+#[cfg(feature = "metrics")]
+use snarkos_metrics::gauge;
 
 /// Messages sent to the proposer about our own batch digests
 #[derive(Debug)]
@@ -433,8 +435,10 @@ impl Proposer {
                 // Advance to the next round.
                 self.round += 1;
                 let _ = self.tx_narwhal_round_updates.send(self.round);
-                // TODO(metrics): Set `current_round` to `self.round as i64`
+
+                #[cfg(feature = "metrics")]
                 gauge!(snarkos_metrics::primary::CURRENT_ROUND, self.round as f64);
+
                 debug!("Dag moved to round {}", self.round);
 
                 // Make a new header.


### PR DESCRIPTION
This PR adds various metrics to bullshark-bft.

## Dependencies

Points to the snarkOS `bft_testnet3` branch for the `snarkos-node-metrics` dependency.