### PR TITLE
feat: set metrics feature as default

### DIFF
--- a/narwhal/node/Cargo.toml
+++ b/narwhal/node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [features]
+default= ["metrics"]
 metrics = ["consensus/metrics", "executor/metrics", "network/metrics", "primary/metrics"]
 
 [dependencies]


### PR DESCRIPTION
For some reason, without this, no metrics are ever written by bullshark (although the names are visible in prometheus - as this is managed by snarkOS in `node/metrics/src/names.rs`).

As the current `main` branch is already snarkOS specific anyway, I'd propose to make this feature default. If any other customers would be interested in bullshark, we can disable it in a (specific or generic) branch for that customer.